### PR TITLE
fix(pkg/auth): do not write response body twice

### DIFF
--- a/.changes/unreleased/🐛 Bug Fix-20230420-140702.yaml
+++ b/.changes/unreleased/🐛 Bug Fix-20230420-140702.yaml
@@ -1,0 +1,3 @@
+kind: "\U0001F41B Bug Fix"
+body: Fix writing the same response body twice in auth handler of the controller.
+time: 2023-04-20T14:07:02.796873175+03:00

--- a/pkg/auth/handler.go
+++ b/pkg/auth/handler.go
@@ -39,14 +39,14 @@ func (h *authHandler) GetToken(w http.ResponseWriter, r *http.Request) {
 
 	responseBody, err := json.Marshal(resp)
 	if err != nil {
-		logrus.Error("Error marshalling token")
+		logrus.Error("Error marshaling token")
 		http.Error(w, "Unable to create token", http.StatusInternalServerError)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
-	_, err = w.Write(responseBody)
+
 	if _, err = w.Write(responseBody); err != nil {
 		logrus.Errorf("Error writing response: %s", err.Error())
 	}

--- a/pkg/auth/handler_test.go
+++ b/pkg/auth/handler_test.go
@@ -21,9 +21,9 @@ func TestAuthHandler_GetToken(t *testing.T) {
 	underTest := auth.NewAuthHandler(authService)
 
 	// Arrange.
-	tokenReq := `{"podName": "1234", "podIp": "abc"}`
+	reqBody := strings.NewReader(`{"podName": "1234", "podIp": "abc"}`)
 
-	req, err := http.NewRequest(http.MethodPost, "/", strings.NewReader(tokenReq))
+	req, err := http.NewRequest(http.MethodPost, "/", reqBody)
 	require.NoError(t, err)
 
 	rr := httptest.NewRecorder()

--- a/pkg/auth/handler_test.go
+++ b/pkg/auth/handler_test.go
@@ -1,62 +1,53 @@
 package auth_test
 
 import (
-	"bytes"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/DelineaXPM/dsv-k8s-sidecar/pkg/auth"
 	"github.com/DelineaXPM/dsv-k8s-sidecar/pkg/mocks"
 	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/suite"
+	"github.com/stretchr/testify/require"
 )
 
-type AuthHandlerTestSuite struct {
-	suite.Suite
-	underTest   auth.AuthHandler
-	authService *mocks.MockAuthService
-}
+func TestAuthHandler_GetToken(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
 
-func TestAuthHandlerSuite(t *testing.T) {
-	suite.Run(t, new(AuthHandlerTestSuite))
-}
+	authService := mocks.NewMockAuthService(mockCtrl)
+	underTest := auth.NewAuthHandler(authService)
 
-func (suite *AuthHandlerTestSuite) SetupTest() {
-	mockCtrl := gomock.NewController(suite.T())
-	defer mockCtrl.Finish()
+	// Arrange.
+	tokenReq := `{"podName": "1234", "podIp": "abc"}`
 
-	suite.authService = mocks.NewMockAuthService(mockCtrl)
-	suite.underTest = auth.NewAuthHandler(suite.authService)
-}
-
-func (suite *AuthHandlerTestSuite) TestHandleAuthGet() {
-	// arrange
-	tokenReq := &auth.TokenRequest{
-		PodIp:   "1234",
-		PodName: "abc",
-	}
-
-	tokenResp := &auth.TokenResponse{
-		Token: "foo",
-	}
-
-	body, _ := json.Marshal(tokenReq)
-	req, _ := http.NewRequest("POST", "/", bytes.NewBuffer(body))
+	req, err := http.NewRequest(http.MethodPost, "/", strings.NewReader(tokenReq))
+	require.NoError(t, err)
 
 	rr := httptest.NewRecorder()
 
-	suite.authService.EXPECT().GetToken(gomock.Any()).Return(tokenResp)
+	authService.EXPECT().GetToken(gomock.Any()).Return(
+		&auth.TokenResponse{
+			Token: "foo",
+		},
+	)
 
-	// act
-	suite.underTest.GetToken(rr, req)
+	// Act.
+	underTest.GetToken(rr, req)
 
-	// assert
-	suite.Equal(http.StatusOK, rr.Code)
-	result := new(auth.TokenResponse)
-	json.NewDecoder(rr.Body).Decode(result)
+	// Assert.
+	resp := rr.Result()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
 
-	suite.NotNil(result)
-	suite.Equal("foo", result.Token)
+	respBody, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	require.Equal(t, `{"token":"foo"}`, string(respBody))
+
+	result := &auth.TokenResponse{}
+	err = json.Unmarshal(respBody, result)
+	require.NoError(t, err)
+	require.Equal(t, "foo", result.Token)
 }

--- a/pkg/auth/handler_test.go
+++ b/pkg/auth/handler_test.go
@@ -38,6 +38,7 @@ func TestAuthHandler_GetToken(t *testing.T) {
 	underTest.GetToken(rr, req)
 
 	// Assert.
+	//nolint:bodyclose // The response body is ok not to close in this case.
 	resp := rr.Result()
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 


### PR DESCRIPTION
Minor fix since JSON unmarshaler simply ignored a second JSON object in the response.