### PR TITLE
fix: create .snyk policy file

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,8 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.25.0
+ignore: {}
+patch: {}
+exclude:
+  global:
+    - vendor/
+    - .devcontainer/


### PR DESCRIPTION
Created snyk policy file to ignore vendor/ and .devcontainer/ directories